### PR TITLE
feat: switch to npm registry api

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
 
 export const api = axios.create({
-  baseURL: 'https://api.npms.io/v2',
+  baseURL: 'https://registry.npmjs.com/-/v1',
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { api } from './api.js';
 
 interface GetPackagesResponse {
   data: {
-    results: [
+    objects: [
       {
         package: {
           name: string;
@@ -34,13 +34,13 @@ on('query', async () => {
   try {
     const { data }: GetPackagesResponse = await api.get('/search', {
       params: {
-        q: params,
+        text: params,
       },
     });
 
     const results: JSONRPCResponse<Methods>[] = [];
 
-    data.results.forEach(({ package: result }) => {
+    data.objects.forEach(({ package: result }) => {
       results.push({
         title: `${result.name} | v${result.version}`,
         subtitle: result.description,


### PR DESCRIPTION
Search results are empty when searching for some packages using current api, for example: `eslint-plugin-perfectionist`.

This change switches the api to official api. For details, see: https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md